### PR TITLE
Fix oneJar build task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 
 group = 'edu.umn.msi.gx'
-version = '2.1.0'
+version = '2.1.1'
 
 description = """
     New mzToSQLite removing DOM reading/building and using SAX reading only. 

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,8 @@ task oneJar(type: Jar) {
                     'Main-Class': 'edu.umn.msi.gx.java.Main'
     }
     baseName = project.name
-    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
 }
 
@@ -31,15 +32,16 @@ repositories {
     mavenCentral()
     }
 
+final mztosqlite_dependencies = [
+    'org.apache.logging.log4j:log4j-core:2.11.0',
+    'org.apache.logging.log4j:log4j-api:2.11.0',
+    'org.xerial:sqlite-jdbc:3.21.0',
+    'commons-cli:commons-cli:1.4',
+    'org.apache.commons:commons-lang3:3.7',
+    'org.apache.commons:commons-math3:3.6.1'
+]
+
 dependencies {
-    implementation (
-            [
-                    'org.apache.logging.log4j:log4j-core:2.11.0',
-                    'org.apache.logging.log4j:log4j-api:2.11.0',
-                    'org.xerial:sqlite-jdbc:3.21.0',
-                    'commons-cli:commons-cli:1.4',
-                    'org.apache.commons:commons-lang3:3.7',
-                    'org.apache.commons:commons-math3:3.6.1'
-            ]
-    )
+    implementation mztosqlite_dependencies
+    runtimeClasspath mztosqlite_dependencies
 }


### PR DESCRIPTION
This fixes the oneJar task, which was broken due to incomplete changes made to allow building via Gradle 7. The remaining necessary changes are included in this PR.